### PR TITLE
Prevent duplicate cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-08-03
+
+### Added
+- `DuplicateCaseError` - raised when the same case value is declared more than once
+- Duplicate case detection prevents declaring the same value across multiple `on` clauses
+- Comprehensive test coverage for duplicate case scenarios
+- Documentation for `DuplicateCaseError` in README with examples
+
+### Technical
+- Enhanced case validation with duplicate detection logic
+- Maintained 100% test coverage with new duplicate case test suite
+
 ## [1.0.0] - 2025-08-02
 
 ### Added
@@ -37,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RuboCop linting configuration
 - Development scripts (`bin/setup`, `bin/console`)
 
-[Unreleased]: https://github.com/yourusername/exhaustive_case/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/yourusername/exhaustive_case/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/yourusername/exhaustive_case/releases/tag/v1.0.1
 [1.0.0]: https://github.com/yourusername/exhaustive_case/releases/tag/v1.0.0
 [0.1.0]: https://github.com/yourusername/exhaustive_case/releases/tag/v0.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exhaustive_case (1.0.0)
+    exhaustive_case (1.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,32 @@
 
 Exhaustive case statements for Ruby to prevent bugs from unhandled cases when new values are added to a system.
 
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Installation](#installation)
+- [Usage](#usage)
+- [The Problem](#the-problem)
+- [The Solution](#the-solution)
+- [Enhanced Validation with `of:` Parameter](#enhanced-validation-with-of-parameter)
+- [Error Handling](#error-handling)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Quick Start
+
+```ruby
+require 'exhaustive_case'
+include ExhaustiveCase
+
+# Simple exhaustive case - will raise error if user_status doesn't match any case
+result = exhaustive_case user_status do
+  on(:active) { "User is active" }
+  on(:inactive) { "User is inactive" }
+  on(:pending) { "User is pending approval" }
+end
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -24,6 +50,10 @@ Or install it yourself as:
 ```bash
 $ gem install exhaustive_case
 ```
+
+## Requirements
+
+- Ruby 2.7 or higher
 
 ## Usage
 
@@ -68,11 +98,11 @@ For instance, with a constant set of inputs `['A', 'B', 'C']`:
 
 ```ruby
 if letter == 'A'
-  // handle a
+  # handle a
 elsif letter == 'B'
-  // handle b
-else // implicit c
-  // handle c 
+  # handle b
+else # implicit c
+  # handle c 
 end
 ```
 
@@ -80,11 +110,11 @@ However, if a new entry `D` is introduced to the system, now:
 
 ```ruby
 if letter == 'A'
-  // code to handle a (whoops!)
+  # code to handle a (whoops!)
 elsif letter == 'B'
-  // code to handle b (whoops!)
-else // implicit c and d
-  // code to handle c  (whoops!)
+  # code to handle b (whoops!)
+else # implicit c and d
+  # code to handle c  (whoops!)
 end
 ```
 
@@ -94,11 +124,11 @@ We can address this with a more explicit initial switch:
 
 ```ruby
 if letter == 'A'
-  // handle a
+  # handle a
 elsif letter == 'B'
-  // handle b
+  # handle b
 elsif letter == 'C'
-  // handle c
+  # handle c
 else 
   raise "Unknown letter #{letter}"
 end
@@ -111,11 +141,11 @@ Note: for these examples, we're using an if/elsif/else chain, but the same conce
 ```ruby
 case letter
 when 'A'
-  // handle a
+  # handle a
 when 'B'
-  // handle b
+  # handle b
 when 'C'
-  // handle c
+  # handle c
 else 
   raise "Unknown letter #{letter}"
 end
@@ -134,9 +164,9 @@ Enter exhaustive case:
 
 ```ruby
 exhaustive_case letter do 
-  on('A') { // handle A }
-  on('B') { // handle B }
-  on('C') { // handle C }
+  on('A') { # handle A }
+  on('B') { # handle B }
+  on('C') { # handle C }
 end
 ```
 
@@ -147,8 +177,8 @@ with the new syntax, `exhaustive_case` handles the final else statement and rais
 
 ```ruby
 exhaustive_case letter do 
-  on('A') { // handle A }
-  on('B', 'C') { // handle B or C }
+  on('A') { # handle A }
+  on('B', 'C') { # handle B or C }
 end
 ```
 
@@ -168,9 +198,9 @@ For even stronger guarantees, you can specify the complete list of acceptable in
 VALID_LETTERS = ['A', 'B', 'C'].freeze
 
 exhaustive_case letter, of: VALID_LETTERS do 
-  on('A') { // handle A }
-  on('B') { // handle B }
-  on('C') { // handle C }
+  on('A') { # handle A }
+  on('B') { # handle B }
+  on('C') { # handle C }
 end
 ```
 
@@ -208,9 +238,35 @@ if a new status is added to `STATUSES` a test suite should reveal that a case is
 
 The following are the expected errors when using the gem:
 
-- **`UnhandledCaseError`** - Raised when the input value doesn't match any `on` clause
-- **`InvalidCaseError`** - Raised when using `of:` and an `on` clause contains a value not in the allowed list
-- **`MissingCaseError`** - Raised when using `of:` and not all allowed values have corresponding `on` clauses
+### `UnhandledCaseError`
+Raised when the input value doesn't match any `on` clause:
+```ruby
+exhaustive_case :unknown_status do
+  on(:active) { "active" }
+  on(:inactive) { "inactive" }
+end
+# => ExhaustiveCase::UnhandledCaseError: No case matched for value: :unknown_status
+```
+
+### `InvalidCaseError` 
+Raised when using `of:` and an `on` clause contains a value not in the allowed list:
+```ruby
+exhaustive_case status, of: [:active, :inactive] do
+  on(:active) { "active" }
+  on(:pending) { "pending" }  # :pending not in allowed list
+end
+# => ExhaustiveCase::InvalidCaseError: Case :pending is not in the allowed list: [:active, :inactive]
+```
+
+### `MissingCaseError`
+Raised when using `of:` and not all allowed values have corresponding `on` clauses:
+```ruby
+exhaustive_case status, of: [:active, :inactive, :pending] do
+  on(:active) { "active" }
+  # Missing :inactive and :pending cases
+end
+# => ExhaustiveCase::MissingCaseError: Missing cases for: [:inactive, :pending]
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,23 @@ end
 # => ExhaustiveCase::MissingCaseError: Missing cases for: [:inactive, :pending]
 ```
 
+### `DuplicateCaseError`
+Raised when the same case value is declared more than once:
+```ruby
+exhaustive_case status do
+  on(:active) { "first active" }
+  on(:active) { "second active" }  # Duplicate case
+end
+# => ExhaustiveCase::DuplicateCaseError: Duplicate case(s): :active. Each case value can only be declared once.
+
+# Also applies when values appear across multiple on clauses
+exhaustive_case status do
+  on(:active, :pending) { "first group" }
+  on(:pending, :inactive) { "second group" }  # :pending is duplicated
+end
+# => ExhaustiveCase::DuplicateCaseError: Duplicate case(s): :pending. Each case value can only be declared once.
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/ajsharma/exhaustive_case.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Exclusive Case
 
+Exhaustive case statements for Ruby to prevent bugs from unhandled cases when enumerated values are added to or removed a system.
+
 [![Gem Version](https://badge.fury.io/rb/exhaustive_case.svg)](https://badge.fury.io/rb/exhaustive_case)
 [![CI](https://github.com/ajsharma/exhaustive_case/actions/workflows/ci.yml/badge.svg)](https://github.com/ajsharma/exhaustive_case/actions/workflows/ci.yml)
 
-Exhaustive case statements for Ruby to prevent bugs from unhandled cases when new values are added to a system.
 
 ## Table of Contents
 
@@ -90,7 +91,7 @@ class UserRenderer
 end
 ```
 
-## The problem
+## The Problem
 
 If/else statements can easily lead to mistake flows when introducing new cases across the systems.
 
@@ -156,7 +157,7 @@ This new syntax is better, but leaves some gaps:
 1. Engineers taught to use the class `if/else` structure constantly introduce these problems.
 2. The final raise statement is often "impossible" to access via testing, it's nature preventing access without mocking (especially when these types of clauses are part of private functions).
 
-## The solution
+## The Solution
 
 But what if had a new type of case statement that could both ensure that all cases are correctly implemented and provide feedback if a new case has been introduced but not implemented?
 

--- a/lib/exhaustive_case.rb
+++ b/lib/exhaustive_case.rb
@@ -35,6 +35,9 @@ module ExhaustiveCase
   # implemented
   class MissingCaseError < Error; end
 
+  # Indicates that a case value was declared more than once
+  class DuplicateCaseError < Error; end
+
   def exhaustive_case(value, of: nil, &block)
     builder = CaseBuilder.new(value, of)
     builder.instance_eval(&block)

--- a/lib/exhaustive_case/version.rb
+++ b/lib/exhaustive_case/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExhaustiveCase
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/exhaustive_case/exhaustive_case_spec.rb
+++ b/spec/exhaustive_case/exhaustive_case_spec.rb
@@ -49,63 +49,127 @@ RSpec.describe ExhaustiveCase do
       expect(result).to eq("it's a symbol")
     end
 
-    context "with 'of' parameter" do
-      it "validates that all cases belong to the 'of' list" do
-        result = exhaustive_case("A", of: %w[A B C]) do
-          on("A") { "handled A" }
-          on("B") { "handled B" }
-          on("C") { "handled C" }
+    it "raises DuplicateCaseError when the same value is declared twice" do
+      expect do
+        exhaustive_case("A") do
+          on("A") { "first A" }
+          on("A") { "second A" }
         end
+      end.to raise_error(ExhaustiveCase::DuplicateCaseError, /Duplicate case\(s\): "A"/)
+    end
 
-        expect(result).to eq("handled A")
+    it "raises DuplicateCaseError when a value appears in multiple on clauses" do
+      expect do
+        exhaustive_case("B") do
+          on("A", "B") { "first occurrence of B" }
+          on("B", "C") { "second occurrence of B" }
+        end
+      end.to raise_error(ExhaustiveCase::DuplicateCaseError, /Duplicate case\(s\): "B"/)
+    end
+
+    it "raises DuplicateCaseError for multiple duplicate values" do
+      expect do
+        exhaustive_case("A") do
+          on("A", "B") { "first" }
+          on("A", "B", "C") { "second" }
+        end
+      end.to raise_error(ExhaustiveCase::DuplicateCaseError, /Duplicate case\(s\): "A", "B"/)
+    end
+
+    it "allows the same value across different data types without duplication error" do
+      result = exhaustive_case("1") do
+        on("1") { "string one" }
+        on(1) { "number one" }
       end
 
-      it "raises InvalidCaseError when a case is not in the 'of' list" do
+      expect(result).to eq("string one")
+    end
+
+    it "works correctly with symbols and duplicate detection" do
+      expect do
+        exhaustive_case(:active) do
+          on(:active) { "first active" }
+          on(:inactive, :active) { "second active" }
+        end
+      end.to raise_error(ExhaustiveCase::DuplicateCaseError, /Duplicate case\(s\): :active/)
+    end
+
+    context "with 'of' parameter" do
+      it "raises InvalidCaseError before DuplicateCaseError when both conditions occur" do
         expect do
           exhaustive_case("A", of: %w[A B C]) do
-            on("A") { "handled A" }
-            on("D") { "handled D" } # D is not in the 'of' list
+            on("A") { "first A" }
+            on("A", "D") { "second A with invalid D" }
           end
         end.to raise_error(ExhaustiveCase::InvalidCaseError, /Invalid case\(s\): "D"/)
       end
 
-      it "raises MissingCaseError when not all 'of' values are handled" do
+      it "prevents duplicate cases while ensuring completeness" do
         expect do
           exhaustive_case("A", of: %w[A B C]) do
             on("A") { "handled A" }
             on("B") { "handled B" }
-            # Missing case for "C"
+            on("B") { "duplicate B" }
           end
-        end.to raise_error(ExhaustiveCase::MissingCaseError, /Missing case\(s\): "C"/)
+        end.to raise_error(ExhaustiveCase::DuplicateCaseError, /Duplicate case\(s\): "B"/)
+      end
+    end
+
+    it "validates that all cases belong to the 'of' list" do
+      result = exhaustive_case("A", of: %w[A B C]) do
+        on("A") { "handled A" }
+        on("B") { "handled B" }
+        on("C") { "handled C" }
       end
 
-      it "allows multiple values in a single 'on' clause when using 'of'" do
-        result = exhaustive_case("B", of: %w[A B C]) do
+      expect(result).to eq("handled A")
+    end
+
+    it "raises InvalidCaseError when a case is not in the 'of' list" do
+      expect do
+        exhaustive_case("A", of: %w[A B C]) do
           on("A") { "handled A" }
-          on("B", "C") { "handled B or C" }
+          on("D") { "handled D" } # D is not in the 'of' list
         end
+      end.to raise_error(ExhaustiveCase::InvalidCaseError, /Invalid case\(s\): "D"/)
+    end
 
-        expect(result).to eq("handled B or C")
-      end
-
-      it "works with different data types in 'of' list" do
-        result = exhaustive_case(:success, of: %i[success failure pending]) do
-          on(:success) { "Operation succeeded" }
-          on(:failure) { "Operation failed" }
-          on(:pending) { "Operation pending" }
+    it "raises MissingCaseError when not all 'of' values are handled" do
+      expect do
+        exhaustive_case("A", of: %w[A B C]) do
+          on("A") { "handled A" }
+          on("B") { "handled B" }
+          # Missing case for "C"
         end
+      end.to raise_error(ExhaustiveCase::MissingCaseError, /Missing case\(s\): "C"/)
+    end
 
-        expect(result).to eq("Operation succeeded")
+    it "allows multiple values in a single 'on' clause when using 'of'" do
+      result = exhaustive_case("B", of: %w[A B C]) do
+        on("A") { "handled A" }
+        on("B", "C") { "handled B or C" }
       end
 
-      it "raises error for multiple invalid cases" do
-        expect do
-          exhaustive_case("A", of: %w[A B C]) do
-            on("A") { "handled A" }
-            on("D", "E") { "handled D or E" } # Both D and E are not in the 'of' list
-          end
-        end.to raise_error(ExhaustiveCase::InvalidCaseError, /Invalid case\(s\): "D", "E"/)
+      expect(result).to eq("handled B or C")
+    end
+
+    it "works with different data types in 'of' list" do
+      result = exhaustive_case(:success, of: %i[success failure pending]) do
+        on(:success) { "Operation succeeded" }
+        on(:failure) { "Operation failed" }
+        on(:pending) { "Operation pending" }
       end
+
+      expect(result).to eq("Operation succeeded")
+    end
+
+    it "raises error for multiple invalid cases" do
+      expect do
+        exhaustive_case("A", of: %w[A B C]) do
+          on("A") { "handled A" }
+          on("D", "E") { "handled D or E" } # Both D and E are not in the 'of' list
+        end
+      end.to raise_error(ExhaustiveCase::InvalidCaseError, /Invalid case\(s\): "D", "E"/)
     end
   end
 end

--- a/spec/exhaustive_case/exhaustive_case_spec.rb
+++ b/spec/exhaustive_case/exhaustive_case_spec.rb
@@ -94,82 +94,80 @@ RSpec.describe ExhaustiveCase do
       end.to raise_error(ExhaustiveCase::DuplicateCaseError, /Duplicate case\(s\): :active/)
     end
 
-    context "with 'of' parameter" do
-      it "raises InvalidCaseError before DuplicateCaseError when both conditions occur" do
-        expect do
-          exhaustive_case("A", of: %w[A B C]) do
-            on("A") { "first A" }
-            on("A", "D") { "second A with invalid D" }
-          end
-        end.to raise_error(ExhaustiveCase::InvalidCaseError, /Invalid case\(s\): "D"/)
-      end
-
-      it "prevents duplicate cases while ensuring completeness" do
-        expect do
-          exhaustive_case("A", of: %w[A B C]) do
-            on("A") { "handled A" }
-            on("B") { "handled B" }
-            on("B") { "duplicate B" }
-          end
-        end.to raise_error(ExhaustiveCase::DuplicateCaseError, /Duplicate case\(s\): "B"/)
-      end
-    end
-
-    it "validates that all cases belong to the 'of' list" do
-      result = exhaustive_case("A", of: %w[A B C]) do
-        on("A") { "handled A" }
-        on("B") { "handled B" }
-        on("C") { "handled C" }
-      end
-
-      expect(result).to eq("handled A")
-    end
-
-    it "raises InvalidCaseError when a case is not in the 'of' list" do
+    it "raises InvalidCaseError before DuplicateCaseError when both conditions occur" do
       expect do
         exhaustive_case("A", of: %w[A B C]) do
-          on("A") { "handled A" }
-          on("D") { "handled D" } # D is not in the 'of' list
+          on("A") { "first A" }
+          on("A", "D") { "second A with invalid D" }
         end
       end.to raise_error(ExhaustiveCase::InvalidCaseError, /Invalid case\(s\): "D"/)
     end
 
-    it "raises MissingCaseError when not all 'of' values are handled" do
+    it "prevents duplicate cases while ensuring completeness" do
       expect do
         exhaustive_case("A", of: %w[A B C]) do
           on("A") { "handled A" }
           on("B") { "handled B" }
-          # Missing case for "C"
+          on("B") { "duplicate B" }
         end
-      end.to raise_error(ExhaustiveCase::MissingCaseError, /Missing case\(s\): "C"/)
+      end.to raise_error(ExhaustiveCase::DuplicateCaseError, /Duplicate case\(s\): "B"/)
+    end
+  end
+
+  it "validates that all cases belong to the 'of' list" do
+    result = exhaustive_case("A", of: %w[A B C]) do
+      on("A") { "handled A" }
+      on("B") { "handled B" }
+      on("C") { "handled C" }
     end
 
-    it "allows multiple values in a single 'on' clause when using 'of'" do
-      result = exhaustive_case("B", of: %w[A B C]) do
+    expect(result).to eq("handled A")
+  end
+
+  it "raises InvalidCaseError when a case is not in the 'of' list" do
+    expect do
+      exhaustive_case("A", of: %w[A B C]) do
         on("A") { "handled A" }
-        on("B", "C") { "handled B or C" }
+        on("D") { "handled D" } # D is not in the 'of' list
       end
+    end.to raise_error(ExhaustiveCase::InvalidCaseError, /Invalid case\(s\): "D"/)
+  end
 
-      expect(result).to eq("handled B or C")
-    end
-
-    it "works with different data types in 'of' list" do
-      result = exhaustive_case(:success, of: %i[success failure pending]) do
-        on(:success) { "Operation succeeded" }
-        on(:failure) { "Operation failed" }
-        on(:pending) { "Operation pending" }
+  it "raises MissingCaseError when not all 'of' values are handled" do
+    expect do
+      exhaustive_case("A", of: %w[A B C]) do
+        on("A") { "handled A" }
+        on("B") { "handled B" }
+        # Missing case for "C"
       end
+    end.to raise_error(ExhaustiveCase::MissingCaseError, /Missing case\(s\): "C"/)
+  end
 
-      expect(result).to eq("Operation succeeded")
+  it "allows multiple values in a single 'on' clause when using 'of'" do
+    result = exhaustive_case("B", of: %w[A B C]) do
+      on("A") { "handled A" }
+      on("B", "C") { "handled B or C" }
     end
 
-    it "raises error for multiple invalid cases" do
-      expect do
-        exhaustive_case("A", of: %w[A B C]) do
-          on("A") { "handled A" }
-          on("D", "E") { "handled D or E" } # Both D and E are not in the 'of' list
-        end
-      end.to raise_error(ExhaustiveCase::InvalidCaseError, /Invalid case\(s\): "D", "E"/)
+    expect(result).to eq("handled B or C")
+  end
+
+  it "works with different data types in 'of' list" do
+    result = exhaustive_case(:success, of: %i[success failure pending]) do
+      on(:success) { "Operation succeeded" }
+      on(:failure) { "Operation failed" }
+      on(:pending) { "Operation pending" }
     end
+
+    expect(result).to eq("Operation succeeded")
+  end
+
+  it "raises error for multiple invalid cases" do
+    expect do
+      exhaustive_case("A", of: %w[A B C]) do
+        on("A") { "handled A" }
+        on("D", "E") { "handled D or E" } # Both D and E are not in the 'of' list
+      end
+    end.to raise_error(ExhaustiveCase::InvalidCaseError, /Invalid case\(s\): "D", "E"/)
   end
 end


### PR DESCRIPTION
If a user does

```ruby
exhaustive_case(input) do 
  on('A') { 1 }
  on('A') { 2 }
end
```

that should be invalid because it's confusing and probably a bug.